### PR TITLE
Configure mongodb uri for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Environment Setup
+
+Before running the application, you need to set up your environment variables. Create a `.env.local` file in the root directory with the following variables:
+
+```bash
+# MongoDB Connection String
+MONGODB_URI=your_mongodb_connection_string
+
+# JWT Secret for authentication
+JWT_SECRET=your_jwt_secret_key
+
+# Next.js Public API Base URL
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+```
+
+You can copy the `.env.example` file and update it with your actual values.
+
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
Add `.env.local` file to resolve `MONGODB_URI is not set` build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bb3cf50-1b98-44a9-9caf-8e818285496e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9bb3cf50-1b98-44a9-9caf-8e818285496e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

